### PR TITLE
Add npm policy, bump CI actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,16 +11,18 @@ jobs:
   publish-images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}
 
       - name: Build and Publish Viewer
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./viewer/Dockerfile
@@ -30,7 +32,7 @@ jobs:
             ${{ github.ref_name == 'main' && 'pcic/pdp-next-viewer:latest' || '' }}
 
       - name: Build and Publish THREDDS
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./thredds
           file: ./thredds/Dockerfile.thredds

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,12 +18,25 @@ jobs:
     name: ESLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          node-version: 20
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
           cache: npm
+
+      - name: Standardize npm
+        run: npm install --global npm@12
+
+      - name: Verify Node/npm toolchain
+        shell: bash
+        run: |
+          echo "Node: $(node --version)"
+          echo "npm:  $(npm --version)"
+          test "$(node --version | cut -d. -f1 | tr -d v)" = "24"
+          test "$(npm --version | cut -d. -f1)" = "12"
 
       - name: Install dependencies
         run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Repository dependency security policy
+min-release-age=7
+strict-allow-scripts=true
+allow-git=none
+allow-remote=none

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "eslint": "^9.0.0"
+  },
+  "engines": {
+    "node": "24.x",
+    "npm": "12.x"
   }
 }


### PR DESCRIPTION
- Require Node 24 and npm 12.
- Add an .npmrc security policy to reduce npm supply-chain risk
- Bump CI actions, pin commit SHAs