### PR TITLE
Add runtime config to enabled portals

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# Local-only runtime configuration for `npm run dev`.
+# Leave ENABLED_PORTALS blank to expose every recognized portal.
+ENABLED_PORTALS=canada_mosaic,prism,vicgl
+DEFAULT_PORTAL_ID=canada_mosaic

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyo
 .venv/
 .env
+.env.local
 */logs/*
 */ncpartitioner-output/*
 node_modules/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,38 @@ PDP_DEV_UPSTREAM=https://beehive.pacificclimate.org \
 npm run dev
 ```
 
+To test a restricted portal rollout locally, use the same environment variables
+as the deployed viewer:
+
+```bash
+ENABLED_PORTALS=canada_mosaic,prism,vicgl \
+DEFAULT_PORTAL_ID=canada_mosaic \
+npm run dev
+```
+
+For a persistent local setup, copy `.env.local.example` to `.env.local` and
+edit the values. `npm run dev` loads `.env.local` when it exists; the file is
+ignored by Git.
+
+### Configure portals at deployment time
+
+The viewer image recognizes the portals declared in `viewer/js/core/config.js`.
+A deployment can expose a subset and choose its default without rebuilding the
+image:
+
+```yaml
+services:
+  viewer:
+    environment:
+      ENABLED_PORTALS: canada_mosaic,prism,vicgl
+      DEFAULT_PORTAL_ID: canada_mosaic
+```
+
+`ENABLED_PORTALS` is a comma-separated list of recognized portal IDs. If it
+is unset or empty, all recognized portals are enabled. If the configured
+default is not enabled, the viewer falls back to `canada_mosaic` when available,
+then to the first enabled portal.
+
 ### Build hardlink mirror
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pdp-next",
   "private": true,
   "scripts": {
-    "dev": "node scripts/dev-viewer.mjs",
+    "dev": "node --env-file-if-exists=.env.local scripts/dev-viewer.mjs",
     "lint": "eslint 'viewer/js/**/*.js' 'viewer/js/*.js'",
     "lint:fix": "eslint --fix 'viewer/js/**/*.js' 'viewer/js/*.js'",
     "lint:ci": "eslint --max-warnings=999 'viewer/js/**/*.js' 'viewer/js/*.js'"

--- a/scripts/dev-viewer.mjs
+++ b/scripts/dev-viewer.mjs
@@ -13,6 +13,10 @@ const port = Number.parseInt(process.env.PDP_DEV_PORT || '4173', 10);
 const upstream = new URL(
   process.env.PDP_DEV_UPSTREAM || 'https://beehive.pacificclimate.org',
 );
+const runtimeConfig = {
+  enabledPortals: process.env.ENABLED_PORTALS || '',
+  defaultPortal: process.env.DEFAULT_PORTAL_ID || '',
+};
 
 if (!Number.isInteger(port) || port < 1 || port > 65535) {
   throw new Error(`Invalid PDP_DEV_PORT: ${process.env.PDP_DEV_PORT}`);
@@ -111,6 +115,17 @@ const server = createServer(async (request, response) => {
   if (requestUrl.pathname === '/') {
     response.writeHead(302, { location: '/pdp-next/' });
     response.end();
+    return;
+  }
+
+  if (requestUrl.pathname === '/pdp-next/runtime-config.js') {
+    const body = `window.PDP_RUNTIME_CONFIG = ${JSON.stringify(runtimeConfig)};\n`;
+    response.writeHead(200, {
+      'cache-control': 'no-store',
+      'content-length': Buffer.byteLength(body),
+      'content-type': 'text/javascript; charset=utf-8',
+    });
+    response.end(request.method === 'HEAD' ? undefined : body);
     return;
   }
 

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -1,9 +1,12 @@
 FROM nginx:alpine
 
 COPY viewer/nginx.conf /etc/nginx/conf.d/default.conf
+COPY viewer/runtime-config.js.template /etc/nginx/templates/runtime-config.js.template
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/usr/share/nginx/html
 COPY viewer/favicon.ico /usr/share/nginx/html/
 RUN chmod 644 /usr/share/nginx/html/favicon.ico
 COPY viewer/pdp-next-viewer.html /usr/share/nginx/html/
+COPY viewer/runtime-config.js /usr/share/nginx/html/
 COPY viewer/viewer.css /usr/share/nginx/html/
 COPY viewer/js /usr/share/nginx/html/js
 COPY viewer/styles /usr/share/nginx/html/styles

--- a/viewer/js/core/config.js
+++ b/viewer/js/core/config.js
@@ -51,6 +51,22 @@ export const TIME_EXPAND_LIMIT = 2000;
 export const NCSS_WARN_TIMESTEPS = 1500;
 export const DEFAULT_PORTAL_ID = "canada_mosaic";
 
+function runtimePortalIds(value) {
+  const values = Array.isArray(value) ? value : String(value || "").split(",");
+  const ids = values.map(normalizePortalId).filter(Boolean);
+  return ids.length ? new Set(ids) : null;
+}
+
+const runtimeConfig = window.PDP_RUNTIME_CONFIG || {};
+const runtimeEnabledPortalIds = runtimePortalIds(runtimeConfig.enabledPortals);
+export const ENABLED_PORTALS = runtimeEnabledPortalIds
+  ? KNOWN_PORTALS.filter((portal) => runtimeEnabledPortalIds.has(portal.id))
+  : KNOWN_PORTALS;
+
+if (!ENABLED_PORTALS.length) {
+  throw new Error("ENABLED_PORTALS does not contain a recognized portal ID");
+}
+
 export const PALETTE_LABELS = {
   default: "Default",
   "seq-Blues": "Sequential Blues",
@@ -105,6 +121,11 @@ export function isKnownPortalId(value) {
   return !!id && KNOWN_PORTALS.some((portal) => portal.id === id);
 }
 
+export function isEnabledPortalId(value) {
+  const id = normalizePortalId(value);
+  return !!id && ENABLED_PORTALS.some((portal) => portal.id === id);
+}
+
 export function buildDefaultPortalConfig(portalId) {
   const id = normalizePortalId(portalId);
   const known = KNOWN_PORTALS.find((portal) => portal.id === id);
@@ -130,10 +151,10 @@ export function buildDefaultPortalConfig(portalId) {
 export function readPortalId() {
   const url = new URL(window.location.href);
   const raw = normalizePortalId(url.searchParams.get(PORTAL_PARAM_KEY));
-  if (isKnownPortalId(raw)) return raw;
+  if (isEnabledPortalId(raw)) return raw;
   const match = url.pathname.match(/\/portal(?:=|\/)([^/]+)\/?$/i);
   const pathPortalId = normalizePortalId(match?.[1]);
-  if (isKnownPortalId(pathPortalId)) return pathPortalId;
+  if (isEnabledPortalId(pathPortalId)) return pathPortalId;
   return null;
 }
 
@@ -226,8 +247,9 @@ export function buildViewerUrl(
 }
 
 export function readDefaultPortalId() {
-  const runtimeDefault = window.PDP_DEFAULT_PORTAL_ID;
+  const runtimeDefault = runtimeConfig.defaultPortal || window.PDP_DEFAULT_PORTAL_ID;
   const candidate = normalizePortalId(runtimeDefault || DEFAULT_PORTAL_ID);
-  if (!candidate) return null;
-  return isKnownPortalId(candidate) ? candidate : DEFAULT_PORTAL_ID;
+  if (candidate && isEnabledPortalId(candidate)) return candidate;
+  if (isEnabledPortalId(DEFAULT_PORTAL_ID)) return DEFAULT_PORTAL_ID;
+  return ENABLED_PORTALS[0]?.id || null;
 }

--- a/viewer/js/portal/menu.js
+++ b/viewer/js/portal/menu.js
@@ -1,6 +1,6 @@
 import {
   DEFAULT_VARIABLE_LABELS,
-  KNOWN_PORTALS,
+  ENABLED_PORTALS,
 } from '../core/config.js';
 
 function setActiveMenuItem(el) {
@@ -217,9 +217,9 @@ export function createMenuController({
 
   function populatePortalSelect() {
     portalSelect.innerHTML = '';
-    const ids = Array.from(new Set([...KNOWN_PORTALS.map((p) => p.id), portal.id])).filter(Boolean);
+    const ids = Array.from(new Set([...ENABLED_PORTALS.map((p) => p.id), portal.id])).filter(Boolean);
     ids.forEach((id) => {
-      const meta = KNOWN_PORTALS.find((p) => p.id === id);
+      const meta = ENABLED_PORTALS.find((p) => p.id === id);
       const opt = document.createElement('option');
       opt.value = id;
       opt.textContent = meta?.title || id;

--- a/viewer/nginx.conf
+++ b/viewer/nginx.conf
@@ -9,6 +9,11 @@ server {
     log_not_found off;
     access_log off;
   }
+
+  location = /runtime-config.js {
+    add_header Cache-Control "no-store";
+    try_files $uri =404;
+  }
  
   location /portal-meta/ {
     alias /portal-meta/;

--- a/viewer/pdp-next-viewer.html
+++ b/viewer/pdp-next-viewer.html
@@ -224,6 +224,7 @@
     </form>
   </dialog>
 
+  <script src="/pdp-next/runtime-config.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/ol@v8.2.0/dist/ol.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/proj4@2.11.0/dist/proj4.js"></script>
   <script type="module" src="/pdp-next/js/app.js"></script>

--- a/viewer/runtime-config.js
+++ b/viewer/runtime-config.js
@@ -1,0 +1,1 @@
+window.PDP_RUNTIME_CONFIG = window.PDP_RUNTIME_CONFIG || {};

--- a/viewer/runtime-config.js.template
+++ b/viewer/runtime-config.js.template
@@ -1,0 +1,4 @@
+window.PDP_RUNTIME_CONFIG = {
+  enabledPortals: "${ENABLED_PORTALS}",
+  defaultPortal: "${DEFAULT_PORTAL_ID}",
+};


### PR DESCRIPTION
[Demo](https://beehive.pacificclimate.org/pdp-next/portal/?portal=prism)

Allows us to enable portals as needed, this will allow us to deploy recently merged updates to prod while still only publishing PRISM and Canada Mosaics. 

Resolves #20 